### PR TITLE
Avoid overhead of pushing many items to candidates list

### DIFF
--- a/js/boid.js
+++ b/js/boid.js
@@ -24,19 +24,25 @@ class Boid extends V2D {
 	}
 
 	neighbors(flock) {
-		const cand = flock.candidates(this);
+		const cands = flock.candidates(this);
 		const ns = [];
 		const ds = [];
 
-		let step = opt.accuracy === 0 ? 1 : Math.ceil(cand.length / opt.accuracy);
+		const candidate_count = cands.map(c => c.length).reduce((a, b) => a + b, 0);
+		let step = opt.accuracy === 0 ? 1 : Math.ceil(candidate_count / opt.accuracy);
+		let i = Math.floor(random(step));
 
-		for (let i = Math.floor(random(step)); i < cand.length; i += step) {
-			if (!cand[i]) break;
-			const d = this.sqrDist(cand[i]);
-			if (d < g.sqVis && this !== cand[i]) {
-				ns.push(cand[i]);
-				ds.push(d);
+		for (const c of cands) {
+			for (; i < c.length; i += step) {
+				if (this === c[i]) continue;
+
+				const d = this.sqrDist(c[i]);
+				if (d < g.sqVis) {
+					ns.push(c[i]);
+					ds.push(d);
+				}
 			}
+			i -= c.length;
 		}
 
 		return [ns, ds];

--- a/js/flock.js
+++ b/js/flock.js
@@ -102,9 +102,10 @@ class Flock {
 	}
 
 	_b(r, c, a) {
-		if (this.buckets[r]?.[c]) a.push(...this.buckets[r][c]);
+		if (this.buckets[r]?.[c]) a.push(this.buckets[r][c]);
 	}
 
+	// Returns a list of lists of boids, where each sublist contains the boids in a nearby cell
 	candidates(boid) {
 		const cand = [];
 


### PR DESCRIPTION
I noticed that the framerate dropped significantly when I turned the boid slider up to 4000 and clicked to drag many boids to one spot, so I decided to run a profile. The line that was taking the most time was [this one](https://github.com/cubedhuang/boids/blob/43950c0b337fc082bc369af9d03833584b876ca6/js/flock.js#L105) where the boids of neighboring cells were all being added to one big list. By returning a list of the lists in these cells instead we avoid having to create enormous lists for every boid on every frame. It just makes iterating over the candidates while skipping some for the accuracy optimization a bit more involved.