### PR TITLE
Fix boid speed depending on framerate

### DIFF
--- a/js/boid.js
+++ b/js/boid.js
@@ -139,7 +139,7 @@ class Boid extends V2D {
 		}
 
 		this.vel.max(opt.maxSpeed);
-		this.add(this.vel);
+		this.sclAdd(this.vel, g.delta);
 
 		if (opt.bounce) {
 			let ran = false;


### PR DESCRIPTION
I noticed that the speed of the simulation changed depending on which of my monitors it was on, scaling with their refresh rate. This simple fix resolves that.